### PR TITLE
Token transfer controller initial implementation

### DIFF
--- a/contracts/ERC165.sol
+++ b/contracts/ERC165.sol
@@ -1,0 +1,11 @@
+/*
+ * Hubii Striim
+ *
+ * Copyright (C) 2017-2018 Hubii AS
+ */
+
+pragma solidity ^0.4.24;
+
+interface ERC165 {
+    function supportsInterface(bytes4 _interfaceId) external view returns (bool);
+}

--- a/contracts/ERC20.sol
+++ b/contracts/ERC20.sol
@@ -8,11 +8,13 @@ pragma solidity ^0.4.24;
 
 contract ERC20 {
     uint256 public totalSupply;
+
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
     function balanceOf(address who) public constant returns (uint256);
     function transfer(address to, uint256 value) public returns (bool);
-    event Transfer(address indexed from, address indexed to, uint256 value);
     function allowance(address owner, address spender) public constant returns (uint256);
     function transferFrom(address from, address to, uint256 value) public returns (bool);
     function approve(address spender, uint256 value) public returns (bool);
-    event Approval(address indexed owner, address indexed spender, uint256 value);
 }

--- a/contracts/ERC20Controller.sol
+++ b/contracts/ERC20Controller.sol
@@ -8,14 +8,14 @@
 
 pragma solidity ^0.4.24;
 
-import {TokenTypeInterface} from "./TokenTypeInterface.sol";
+import {TokenController} from "./TokenController.sol";
 import "./ERC20.sol";
 
 /**
 @title ERC20Controller
 @notice Handles transfers of an ERC20 token
 */
-contract ERC20Controller is TokenTypeInterface {
+contract ERC20Controller is TokenController {
     function isTyped() public view returns(bool) {
         return false;
     }

--- a/contracts/ERC20Controller.sol
+++ b/contracts/ERC20Controller.sol
@@ -1,0 +1,51 @@
+/*
+ * Hubii Striim
+ *
+ * Compliant with the Hubii Striim specification v0.12.
+ *
+ * Copyright (C) 2017-2018 Hubii AS
+ */
+
+pragma solidity ^0.4.24;
+
+import {TokenTypeInterface} from "./TokenTypeInterface.sol";
+import "./ERC20.sol";
+
+/**
+@title ERC20Controller
+@notice Handles transfers of an ERC20 token
+*/
+contract ERC20Controller is TokenTypeInterface {
+    function isTyped() public view returns(bool) {
+        return false;
+    }
+
+    function isQuantifiable() public view returns(bool) {
+        return true;
+    }
+
+    function receive(address token, address from, address to, uint256 amount, uint256 id) public {
+        require(amount > 0);
+        require(id == 0);
+
+        ERC20 erc20 = ERC20(token);
+        require(erc20.transferFrom(from, to, uint256(amount)));
+
+        //raise event
+        emit TokenTransferred(token, from, to, amount, 0);
+    }
+
+    function send(address token, address to, uint256 amount, uint256 id) public {
+        require(msg.sender != address(0));
+        require(amount > 0);
+        require(id == 0);
+
+        ERC20 erc20 = ERC20(token);
+        require(erc20.approve(to, amount));
+        require(erc20.transferFrom(msg.sender, to, amount));
+
+        //raise event
+        emit TokenTransferred(token, msg.sender, to, amount, 0);
+    }
+}
+

--- a/contracts/ERC721.sol
+++ b/contracts/ERC721.sol
@@ -1,0 +1,38 @@
+/*
+ * Hubii Striim
+ *
+ * Copyright (C) 2017-2018 Hubii AS
+ */
+
+pragma solidity ^0.4.24;
+
+import "./ERC165.sol";
+
+contract ERC721 is ERC165 {
+    bytes4 internal constant InterfaceId_ERC721 = 0x80ac58cd;
+    bytes4 internal constant InterfaceId_ERC721Exists = 0x4f558e79;
+    bytes4 internal constant InterfaceId_ERC721Enumerable = 0x780e9d63;
+    bytes4 internal constant InterfaceId_ERC721Metadata = 0x5b5e139f;
+
+    event Transfer(address indexed _from, address indexed _to, uint256 indexed _tokenId);
+    event Approval(address indexed _owner, address indexed _approved, uint256 indexed _tokenId);
+    event ApprovalForAll(address indexed _owner, address indexed _operator, bool _approved);
+
+    function balanceOf(address _owner) public view returns (uint256 _balance);
+    function ownerOf(uint256 _tokenId) public view returns (address _owner);
+    function exists(uint256 _tokenId) public view returns (bool _exists);
+    function approve(address _to, uint256 _tokenId) public;
+    function getApproved(uint256 _tokenId) public view returns (address _operator);
+    function setApprovalForAll(address _operator, bool _approved) public;
+    function isApprovedForAll(address _owner, address _operator) public view returns (bool);
+    function transferFrom(address _from, address _to, uint256 _tokenId) public;
+    function safeTransferFrom(address _from, address _to, uint256 _tokenId) public;
+    function safeTransferFrom(address _from, address _to, uint256 _tokenId, bytes _data) public;
+
+    function totalSupply() public view returns (uint256);
+    function tokenOfOwnerByIndex( address _owner, uint256 _index) public view returns (uint256 _tokenId);
+
+    function name() external view returns (string _name);
+    function symbol() external view returns (string _symbol);
+    function tokenURI(uint256 _tokenId) public view returns (string);
+}

--- a/contracts/ERC721Controller.sol
+++ b/contracts/ERC721Controller.sol
@@ -8,14 +8,14 @@
 
 pragma solidity ^0.4.24;
 
-import {TokenTypeInterface} from "./TokenTypeInterface.sol";
+import {TokenController} from "./TokenController.sol";
 import "./ERC721.sol";
 
 /**
 @title ERC721Controller
 @notice Handles transfers of an ERC721 token
 */
-contract ERC721Controller is TokenTypeInterface {
+contract ERC721Controller is TokenController {
     function isTyped() public view returns (bool) {
         return true;
     }

--- a/contracts/ERC721Controller.sol
+++ b/contracts/ERC721Controller.sol
@@ -1,0 +1,50 @@
+/*
+ * Hubii Striim
+ *
+ * Compliant with the Hubii Striim specification v0.12.
+ *
+ * Copyright (C) 2017-2018 Hubii AS
+ */
+
+pragma solidity ^0.4.24;
+
+import {TokenTypeInterface} from "./TokenTypeInterface.sol";
+import "./ERC721.sol";
+
+/**
+@title ERC721Controller
+@notice Handles transfers of an ERC721 token
+*/
+contract ERC721Controller is TokenTypeInterface {
+    function isTyped() public view returns (bool) {
+        return true;
+    }
+
+    function isQuantifiable() public view returns (bool) {
+        return false;
+    }
+
+    function receive(address token, address from, address to, uint256 amount, uint256 id) public {
+        require(amount == 1);
+        require(id != 0);
+
+        ERC721 erc721 = ERC721(token);
+        erc721.safeTransferFrom(from, to, id);
+
+        //raise event
+        emit TokenTransferred(token, from, to, 1, id);
+    }
+
+    function send(address token, address to, uint256 amount, uint256 id) public {
+        require(msg.sender != address(0));
+        require(amount == 1);
+        require(id != 0);
+
+        ERC721 erc721 = ERC721(token);
+        erc721.approve(to, id);
+        erc721.safeTransferFrom(msg.sender, to, id);
+
+        //raise event
+        emit TokenTransferred(token, msg.sender, to, 1, id);
+    }
+}

--- a/contracts/TokenController.sol
+++ b/contracts/TokenController.sol
@@ -9,10 +9,10 @@
 pragma solidity ^0.4.24;
 
 /**
-@title TokenTypeInterface
+@title TokenController
 @notice A base contract to handle different token types
 */
-contract TokenTypeInterface {
+contract TokenController {
     event TokenTransferred(address token, address from, address to, uint256 amount, uint256 id);
 
     function isTyped() public view returns(bool);

--- a/contracts/TokenManager.sol
+++ b/contracts/TokenManager.sol
@@ -1,0 +1,121 @@
+/*
+ * Hubii Striim
+ *
+ * Compliant with the Hubii Striim specification v0.12.
+ *
+ * Copyright (C) 2017-2018 Hubii AS
+ */
+
+pragma solidity ^0.4.24;
+
+import {Ownable} from "./Ownable.sol";
+import {SelfDestructible} from "./SelfDestructible.sol";
+import "./ERC20Controller.sol";
+import "./ERC721Controller.sol";
+
+/**
+@title TokenManager
+@notice Handles registration of tokens
+*/
+contract TokenManager is Ownable, SelfDestructible {
+    //
+    // Constants
+    // -----------------------------------------------------------------------------------------------------------------
+    uint32 constant BLACKLISTED = 2147483648;
+
+    //
+    // Variables
+    // -----------------------------------------------------------------------------------------------------------------
+    mapping(uint32 => address) registeredInterfaces;
+    mapping(address => uint32) registeredTokens;
+
+    //
+    // Events
+    // -----------------------------------------------------------------------------------------------------------------
+    event RegisteredInterface(uint32 _id, address _interface);
+    event DeregisteredInterface(uint32 _id);
+
+    event RegisteredToken(address token, uint32 interface_id);
+    event DeregisteredToken(address token);
+    event BlacklistedToken(address token);
+    event WhitelistedToken(address token);
+
+    //
+    // Constructor
+    // -----------------------------------------------------------------------------------------------------------------
+    constructor(address owner) Ownable(owner) public {
+    }
+
+    //
+    // Functions
+    // -----------------------------------------------------------------------------------------------------------------
+    function registerInterface(uint32 _id, address _interface) external onlyOwner {
+        require(_id >= 1 && _id <= 1048576);
+        require(_interface != address(0));
+        require(registeredInterfaces[_id] == address(0));
+
+        registeredInterfaces[_id] = _interface;
+
+        //raise event
+        emit RegisteredInterface(_id, _interface);
+    }
+
+    function deregisterInterface(uint32 _id) external onlyOwner {
+        require(registeredInterfaces[_id] != address(0));
+
+        registeredInterfaces[_id] = address(0);
+
+        //raise event
+        emit DeregisteredInterface(_id);
+    }
+
+    function registerToken(address token, uint32 interface_id) external onlyOwner {
+        require(token != address(0));
+        require(interface_id >= 1 && interface_id <= 1048576);
+        require(registeredTokens[token] == 0);
+
+        registeredTokens[token] = interface_id;
+
+        //raise event
+        emit RegisteredToken(token, interface_id);
+    }
+
+    function deregisterToken(address token) external onlyOwner {
+        require(token != address(0));
+        require(registeredTokens[token] != 0);
+
+        registeredTokens[token] = 0;
+
+        //raise event
+        emit DeregisteredToken(token);
+    }
+
+    function blacklistToken(address token) external onlyOwner {
+        require(token != address(0));
+        require(registeredTokens[token] != 0);
+
+        registeredTokens[token] = registeredTokens[token] | BLACKLISTED;
+
+        //raise event
+        emit BlacklistedToken(token);
+    }
+
+    function whitelistToken(address token) external onlyOwner {
+        require(token != address(0));
+        require(registeredTokens[token] != 0);
+
+        registeredTokens[token] = registeredTokens[token] & (~BLACKLISTED);
+
+        //raise event
+        emit WhitelistedToken(token);
+    }
+
+    function getInferface(address token) public view returns (TokenTypeInterface) {
+        uint32 interface_id = registeredTokens[token];
+
+        require(interface_id != 0 && (interface_id & BLACKLISTED) == 0);
+        require(registeredInterfaces[interface_id] != address(0));
+
+        return TokenTypeInterface(registeredInterfaces[interface_id]);
+    }
+}

--- a/contracts/TokenTypeInterface.sol
+++ b/contracts/TokenTypeInterface.sol
@@ -1,0 +1,23 @@
+/*
+ * Hubii Striim
+ *
+ * Compliant with the Hubii Striim specification v0.12.
+ *
+ * Copyright (C) 2017-2018 Hubii AS
+ */
+
+pragma solidity ^0.4.24;
+
+/**
+@title TokenTypeInterface
+@notice A base contract to handle different token types
+*/
+contract TokenTypeInterface {
+    event TokenTransferred(address token, address from, address to, uint256 amount, uint256 id);
+
+    function isTyped() public view returns(bool);
+    function isQuantifiable() public view returns(bool);
+
+    function receive(address token, address from, address to, uint256 amount, uint256 id) public;
+    function send(address token, address to, uint256 amount, uint256 id) public;
+}


### PR DESCRIPTION
The initial draft for doing token transfers of different types.

1. Separated `receive`/`send` so we use the same contract transfer function for doing withdrawal in case the `transfer` function is not correctly implemented.
2. EIP1155 is in a veeeeery alpha stage to implement some handler.
3. Because the different kind of token contracts, added two helper functions to determine if a token is transferred in terms of quantity and/or id.

To-do next: Add the token registration. Unregistered tokens cannot be used in the exchange and the backend will be in charge of registering tokens and types into the system.