### PR TITLE
Mocha TeamCity reporter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5339,6 +5339,15 @@
         }
       }
     },
+    "mocha-teamcity-reporter": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/mocha-teamcity-reporter/-/mocha-teamcity-reporter-2.5.0.tgz",
+      "integrity": "sha512-mIQjUmvnueldPUUym+iCIs5fXjuX5KmJgGEgPpJA0qCpdYG+qqiJduQoGBVlnhWWtQZmEhmO6DehoEqC9F5e4A==",
+      "dev": true,
+      "requires": {
+        "mocha": ">=3.5.0"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "ethereumjs-util": "^5.2.0",
+    "mocha-teamcity-reporter": "^2.5.0",
     "sinon": "^5.0.1",
     "sinon-chai": "^3.0.0",
     "solhint": "^1.1.10"

--- a/truffle.js
+++ b/truffle.js
@@ -1,4 +1,4 @@
-    module.exports = {
+module.exports = {
     networks: {
         development: {
             host: "localhost",
@@ -54,5 +54,8 @@
             enabled: true,
             runs: 0
         }
+    },
+    mocha: {
+        reporter: process.env.MOCHA_REPORTER || 'spec'
     }
 };


### PR DESCRIPTION
Solution to #159.

The TeamCity reporter will be invoked by environment variable: `MOCHA_REPORTER=mocha-teamcity-reporter npx truffle test`